### PR TITLE
Feat/metro network

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,18 @@
 source 'https://rubygems.org'
 
+gem 'activesupport'
 gem 'algorithms', '~> 1.0'
 gem 'factory_bot'
-gem 'guard-rspec'
 gem 'json'
 gem 'json-schema'
-gem 'pry'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', require: false
+
+group :development do
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'pry'
+  gem 'pry-remote'
+  gem 'pry-nav'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     ffi (1.15.3)
-    formatador (0.2.5)
+    formatador (0.3.0)
     guard (2.17.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -41,7 +41,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
-    method_source (1.0.0)
+    method_source (0.9.2)
     minitest (5.14.4)
     nenv (0.3.0)
     notiffany (0.1.3)
@@ -50,9 +50,14 @@ GEM
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.6)
@@ -87,6 +92,7 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     shellany (0.0.1)
+    slop (3.6.0)
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -97,12 +103,16 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  activesupport
   algorithms (~> 1.0)
   factory_bot
+  guard
   guard-rspec
   json
   json-schema
   pry
+  pry-nav
+  pry-remote
   rake
   rspec
   rubocop

--- a/lib/metro.rb
+++ b/lib/metro.rb
@@ -1,0 +1,5 @@
+require 'metro/metro_network'
+require 'metro/edge_cost_map'
+
+module Metro
+end

--- a/lib/metro/edge_cost_map.rb
+++ b/lib/metro/edge_cost_map.rb
@@ -1,0 +1,36 @@
+module Metro
+  class EdgeCostMap
+    attr_accessor :cost_dict
+
+    def initialize
+      @cost_dict = {}
+    end
+
+    def edge_cost(target, train_color, colors)
+      return 1 if train_color == 0
+      return 1 if train_color == colors[target]
+      return 1 if colors[target] == 0
+
+      0
+    end
+
+    def add_edge_cost(a, b, cost)
+      @cost_dict[[a, b]] = cost
+    end
+
+    def get_edge_cost(a, b)
+      return @cost_dict[[a, b]] if @cost_dict.has_key?([a, b])
+    end
+
+    def self.build(adjacencies, colors, train_color)
+      map = new
+      adjacencies.each do |station, adjList|
+        adjList.each do |neighbor|
+          cost = map.edge_cost(neighbor, train_color, colors)
+          map.add_edge_cost(station, neighbor, cost)
+        end
+      end
+      map
+    end
+  end
+end

--- a/lib/metro/metro_network.rb
+++ b/lib/metro/metro_network.rb
@@ -1,0 +1,47 @@
+require 'set'
+
+module Metro
+  class MetroNetwork
+    attr_accessor :stations_adjacency, :stations_color
+
+    def self.build(*data)
+      graph = new
+      data.each do |station|
+        graph.add_station(station[:name])
+        graph.add_station_color(station[:name], station[:color])
+        station[:neighbors].each do |neighbor|
+          graph.add_edge(station[:name], neighbor)
+        end
+      end
+      graph
+    end
+
+    def initialize
+      @stations_adjacency = {}
+      @stations_color = {}
+    end
+
+    def add_station(v)
+      @stations_adjacency[v] ||= Set.new
+    end
+
+    def add_station_color(v, color)
+      @stations_color[v] ||= color
+    end
+
+    def add_edge(source, target)
+      add_station(source)
+      add_station(target)
+      @stations_adjacency[source].add(target)
+    end
+
+    def has_station?(v)
+      @stations_adjacency.has_key?(v)
+    end
+
+    def each_neighbor(station, &a)
+      neighbors = @stations_adjacency[station]
+      neighbors.each(&a)
+    end
+  end
+end

--- a/spec/metro/edge_cost_map_spec.rb
+++ b/spec/metro/edge_cost_map_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+RSpec.describe Metro::EdgeCostMap do
+  def perform
+    described_class
+      .build(adjacencies, colors, train_color)
+      .cost_dict
+  end
+  let(:train_color) { 0 }
+  let(:adjacencies) do
+    {
+      'A' => Set['B'],
+      'B' => Set['A', 'C'],
+      'C' => Set['B', 'D', 'G'],
+      'G' => Set['C', 'H'],
+      'H' => Set['G', 'I'],
+      'I' => Set['F', 'H']
+    }
+  end
+  let (:colors) do
+    {
+      'A' => 0,
+      'B' => 0,
+      'C' => 0,
+      'D' => 0,
+      'G' => 1,
+      'H' => 2,
+      'I' => 1,
+      'F' => 0
+    }
+  end
+
+  describe '#build' do
+    context 'when train has no color' do
+      let(:output_cost_map) do
+        {
+          ['A', 'B'] => 1,
+          ['B', 'A'] => 1,
+          ['B', 'C'] => 1,
+          ['C', 'B'] => 1,
+          ['C', 'D'] => 1,
+          ['C', 'G'] => 1,
+          ['G', 'C'] => 1,
+          ['G', 'H'] => 1,
+          ['H', 'G'] => 1,
+          ['H', 'I'] => 1,
+          ['I', 'H'] => 1,
+          ['I', 'F'] => 1,
+        }
+      end
+      it 'creates correct costs for edges' do
+        expect(perform).to eq(output_cost_map)
+      end
+    end
+
+    context 'when train is green' do
+      let(:train_color) { 1 }
+      let(:output_cost_map) do
+        {
+          ['A', 'B'] => 1,
+          ['B', 'A'] => 1,
+          ['B', 'C'] => 1,
+          ['C', 'B'] => 1,
+          ['C', 'D'] => 1,
+          ['C', 'G'] => 1,
+          ['G', 'C'] => 1,
+          ['G', 'H'] => 0,
+          ['H', 'G'] => 1,
+          ['H', 'I'] => 1,
+          ['I', 'H'] => 0,
+          ['I', 'F'] => 1,
+        }
+      end
+      it 'creates correct costs for edges' do
+        expect(perform).to eq(output_cost_map)
+      end 
+    end
+
+    context 'when train is red' do
+      let(:train_color) { 2 }
+      let(:output_cost_map) do
+        {
+          ['A', 'B'] => 1,
+          ['B', 'A'] => 1,
+          ['B', 'C'] => 1,
+          ['C', 'B'] => 1,
+          ['C', 'D'] => 1,
+          ['C', 'G'] => 0,
+          ['G', 'C'] => 1,
+          ['G', 'H'] => 1,
+          ['H', 'G'] => 0,
+          ['H', 'I'] => 0,
+          ['I', 'H'] => 1,
+          ['I', 'F'] => 1,
+        }
+      end
+      it 'creates correct costs for edges' do
+        expect(perform).to eq(output_cost_map)
+      end 
+    end
+  end
+end

--- a/spec/metro/metro_network_spec.rb
+++ b/spec/metro/metro_network_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Metro::MetroNetwork do
+  let(:metro) { described_class.new }
+  let(:station) { { name: 'A', neighbors: %w[B C], color: 1 } }
+
+  describe '#add_station' do
+    it 'adds station' do
+      metro.add_station(station[:name])
+      expect(metro.stations_adjacency).to have_key('A')
+    end
+  end
+
+  describe '#add_station_color' do
+    it 'adds station color' do
+      metro.add_station_color(station[:name], station[:color])
+      expect(metro.stations_color).to have_key('A')
+      expect(metro.stations_color['A']).to eq(1)
+    end
+  end
+
+  describe '#add_edge' do
+    it 'adds edge' do
+      metro.add_edge('A', 'B')
+      expect(metro.stations_adjacency['A']).to include('B')
+    end
+  end
+
+  describe '#build' do
+    let(:stations) do
+      [
+        { name: 'A', neighbors: %w[B C], color: 1 },
+        { name: 'B', neighbors: ['C'], color: 2 },
+        { name: 'C', neighbors: ['A'], color: 0 }
+      ]
+    end
+    let(:metro) { described_class.build(*stations) }
+    it 'builds the stations of the MetroNetwork' do
+      expect(metro.stations_adjacency).to include('A', 'B', 'C')
+      expect(metro.stations_color).to include('A', 'B', 'C')
+      expect(metro.stations_color['A']).to eq(1)
+      expect(metro.stations_color['B']).to eq(2)
+      expect(metro.stations_color['C']).to eq(0)
+    end
+
+    it 'builds the edges of the MetroNetwork' do
+      expect(metro.stations_adjacency['A']).to include('B', 'C')
+      expect(metro.stations_adjacency['B']).to include('C')
+      expect(metro.stations_adjacency['C']).to include('A')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'metro'
+require 'pry'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -44,57 +47,55 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # This setting enables warnings. It's recommended, but in some cases may
+  #   # be too noisy due to issues in dependencies.
+  #   config.warnings = true
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# Que se esta haciendo

Se implementan dos clases:

1. `EdgeCostMap`: Permite crear un `Hash` que representa los costos de ir de una estacion de metro a otra, dependiendo del color del tren.
2. `MetroNetwork`: Representa la red de metro a partir de un **Grafo Dirigido**. Dicho grafo a su vez es representado a partir de listas de adjacencia.

Se testea que:

1.  Grafo asociado a red de metro sea construido correctamente (vertices, aristas y colores de estaciones)
2. Costos de aristas son calculados correctamente, de acuedo al color del tren