### PR TITLE
refactor(edgeCostMap): EdgeCostMap does not store graph data anymore

### DIFF
--- a/lib/metro/edge_cost_map.rb
+++ b/lib/metro/edge_cost_map.rb
@@ -8,10 +8,8 @@ module Metro
   class EdgeCostMap
     attr_accessor :cost_dict
 
-    def initialize(graph)
+    def initialize
       @cost_dict = {}
-      @colors = graph.stations_color
-      @adjacencies = graph.stations_adjacency
     end
 
     # Calculates the cost of an edge depending on the color of the train
@@ -23,10 +21,10 @@ module Metro
     # In any other case, the train is not allowed to stop at target
     # and thus returns 0
 
-    def edge_cost(target, train_color)
+    def edge_cost(colors, target, train_color)
       return 1 if train_color == :NO
-      return 1 if train_color == @colors[target]
-      return 1 if @colors[target] == :NO
+      return 1 if train_color == colors[target]
+      return 1 if colors[target] == :NO
 
       0
     end
@@ -42,13 +40,15 @@ module Metro
     end
 
     # recalculates all the costs depending on the train color
-    def build(train_color)
-      @adjacencies.each do |station, adj_list|
+    def self.build(graph, train_color)
+      edge_map = new
+      graph.stations_adjacency.each do |station, adj_list|
         adj_list.each do |neighbor|
-          cost = edge_cost(neighbor, train_color)
-          add_edge_cost(station, neighbor, cost)
+          cost = edge_map.edge_cost(graph.stations_color, neighbor, train_color)
+          edge_map.add_edge_cost(station, neighbor, cost)
         end
       end
+      edge_map
     end
   end
 end

--- a/lib/metro/shortest_path.rb
+++ b/lib/metro/shortest_path.rb
@@ -12,7 +12,6 @@ module Metro
 
     def initialize(graph)
       @graph = graph
-      @edge_cost_map = EdgeCostMap.new(graph)
       @distance_map = Hash.new(INF)
       @parents = {}
     end
@@ -30,7 +29,7 @@ module Metro
       return [] if train_cant_start(source, train_color)
 
       setup(source)
-      @edge_cost_map.build(train_color)
+      @edge_cost_map = EdgeCostMap.build(@graph, train_color)
       bfs(target)
       path = RecoverPath.new(source, @parents).recover_path(target)
       clear_path(path, source, target)

--- a/spec/metro/edge_cost_map_spec.rb
+++ b/spec/metro/edge_cost_map_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Metro::EdgeCostMap do
+
   let(:train_color) { :NO }
   let(:stations) do
     [
@@ -12,9 +13,12 @@ RSpec.describe Metro::EdgeCostMap do
   end
 
   let(:graph) { Metro::MetroNetwork.build(*stations) }
-  let(:edge_cost_map) { described_class.new(graph) }
+  let(:edge_cost_map) { described_class.build(graph, train_color) }
 
   describe '#build' do
+    before do
+      described_class.build(graph, train_color)
+    end
     context 'when train has no color' do
       let(:output_cost_map) do
         {
@@ -29,7 +33,6 @@ RSpec.describe Metro::EdgeCostMap do
         }
       end
       it 'edge costs are 1' do
-        edge_cost_map.build(train_color)
         expect(edge_cost_map.cost_dict).to eq(output_cost_map)
       end
     end
@@ -49,7 +52,6 @@ RSpec.describe Metro::EdgeCostMap do
         }
       end
       it 'cost to unsupported stations is 0' do
-        edge_cost_map.build(train_color)
         expect(edge_cost_map.cost_dict).to eq(output_cost_map)
       end
     end
@@ -69,7 +71,6 @@ RSpec.describe Metro::EdgeCostMap do
         }
       end
       it 'cost to unsupported stations is 0' do
-        edge_cost_map.build(train_color)
         expect(edge_cost_map.cost_dict).to eq(output_cost_map)
       end
     end


### PR DESCRIPTION
## Qué se esta haciendo

Se hace un refactor para que `Metro::EdgeCostMap` no tenga que guardar lista de adjacencia.