### PR TITLE
test(main): add tests for Main class in main.rb

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.language": ",es"
+}

--- a/script/main.rb
+++ b/script/main.rb
@@ -25,11 +25,8 @@ class Main
     path = shortest_path_finder.shortest_path(args[:source], args[:target],
                                               args[:train_color])
 
-    if path.empty?
-      puts "No routes fround from #{args[:source]} to #{args[:target]}"
-    else
-      puts "Best Route:\n\t #{path.join(' -> ')} "
-    end
+    return "No routes fround from #{args[:source]} to #{args[:target]}" if path.empty?
+    return "Best Route:\n\t #{path.join(' -> ')} "
   end
 
   def self.display_args(args)
@@ -45,5 +42,6 @@ end
 if $PROGRAM_NAME == __FILE__
 
   args = Metro::CommandLineParser.parse(ARGV)
-  Main.run(args)
+  out = Main.run(args)
+  puts out
 end

--- a/spec/script/main_spec.rb
+++ b/spec/script/main_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Main do
+  def run
+    described_class.run(args)
+  end
+
+  def out(path)
+    return "No routes fround from #{args[:source]} to #{args[:target]}" if path.empty?
+    return "Best Route:\n\t #{path.join(' -> ')} "
+  end
+
+  context 'when route exists' do
+    let(:args) do
+      {
+        train_color: :RED,
+        source: 'A',
+        target:'F',
+        network_file: 'data/base.json'
+      }
+    end
+    it 'returns best route' do
+      expect(run).to eq(out(['A', 'B', 'C', 'H', 'F']))
+    end
+  end
+
+  context 'when route does not exist' do
+    context 'when route exists' do
+      let(:args) do
+        {
+          train_color: :RED,
+          source: 'B',
+          target:'I',
+          network_file: 'data/base.json'
+        }
+      end
+      it 'says there are no routes' do
+        expect(run).to eq(out([]))
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'metro'
 require 'pry'
+require_relative '../script/main.rb'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## Qué se esta haciendo

Se implementan tests para clase `Main`, la cual recibe los argumentos parseados de la CLI y retorna la ruta mas corta.